### PR TITLE
Don't need to use a generator for Reflectable type

### DIFF
--- a/src/org/dt/reflector/Reflector.gwt.xml
+++ b/src/org/dt/reflector/Reflector.gwt.xml
@@ -5,10 +5,6 @@
 
   <!-- Other module inherits                                      -->
 
-  <generate-with class="org.dt.reflector.rebind.ReflectorGenerator">
-    <when-type-assignable class="org.dt.reflector.client.Reflectable" />
-  </generate-with>
-
   <generate-with class="org.dt.reflector.rebind.ReflectionOracleGenerator">
     <when-type-assignable class="org.dt.reflector.client.ReflectionOracle" />
   </generate-with>

--- a/src/org/dt/reflector/Reflector.gwt.xml
+++ b/src/org/dt/reflector/Reflector.gwt.xml
@@ -13,6 +13,9 @@
   <!-- and at the same time define the default type finder so that it is always present -->
   <define-configuration-property name="org.dt.reflector.rebind.finder.typefinder" is-multi-valued="true" />
   <extend-configuration-property name="org.dt.reflector.rebind.finder.typefinder" value="org.dt.reflector.rebind.finder.ReflectableTypesFinder" />
+
+  <define-configuration-property name="org.dt.reflector.rebind.finder.ReflectableTypesFinder.type" is-multi-valued="true" />
+  <extend-configuration-property name="org.dt.reflector.rebind.finder.ReflectableTypesFinder.type" value="org.dt.reflector.client.Reflectable" />
   
   <!-- Specify the paths for translatable code                    -->
   <source path='client'/>

--- a/src/org/dt/reflector/rebind/ReflectionOracleGenerator.java
+++ b/src/org/dt/reflector/rebind/ReflectionOracleGenerator.java
@@ -75,7 +75,7 @@ public class ReflectionOracleGenerator extends Generator {
     JClassType oracleType = context.getTypeOracle().findType(typeName);
     
     String implPackageName = oracleType.getPackage().getName();
-    String implTypeName = oracleType.getSimpleSourceName()+"_OracleImpl";
+    String implTypeName = oracleType.getName()+"_OracleImpl";
     
     ClassSourceFileComposerFactory composerFactory = new ClassSourceFileComposerFactory(implPackageName, implTypeName);
 

--- a/src/org/dt/reflector/rebind/finder/ReflectableTypesFinder.java
+++ b/src/org/dt/reflector/rebind/finder/ReflectableTypesFinder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.dt.reflector.client.Reflectable;
+import org.dt.reflector.rebind.ReflectorGenerator;
 
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
@@ -20,10 +21,10 @@ public class ReflectableTypesFinder implements TypesToReflectFinder {
     
     for (JClassType type : context.getTypeOracle().getTypes()) {
       if (hasMarkerInterface(type, markerType)) {
-        typesToReflect.add(new TypeToReflect(type));
+        typesToReflect.add(getTypeToReflect(logger, context, type));
           for (JClassType nestedType : type.getNestedTypes()) {
             if (hasMarkerInterface(nestedType, markerType)) {
-              typesToReflect.add(new TypeToReflect(nestedType));
+              typesToReflect.add(getTypeToReflect(logger, context, nestedType));
             }
           }
       }
@@ -32,6 +33,11 @@ public class ReflectableTypesFinder implements TypesToReflectFinder {
     return typesToReflect;
   }
 
+  private TypeToReflect getTypeToReflect(TreeLogger logger, GeneratorContext context, JClassType type) throws UnableToCompleteException {
+    String qualifiedSourceName = type.getQualifiedSourceName();
+    String reflectorQualifiedSourceName = new ReflectorGenerator().generate(logger, context, qualifiedSourceName);
+    return new TypeToReflect(qualifiedSourceName, reflectorQualifiedSourceName);
+  }
 
   private JClassType getMarkerInterface(GeneratorContext context) {
     return context.getTypeOracle().findType(Reflectable.class.getName());

--- a/src/org/dt/reflector/rebind/finder/ReflectableTypesFinder.java
+++ b/src/org/dt/reflector/rebind/finder/ReflectableTypesFinder.java
@@ -1,11 +1,14 @@
 package org.dt.reflector.rebind.finder;
 
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
-import org.dt.reflector.client.Reflectable;
 import org.dt.reflector.rebind.ReflectorGenerator;
 
+import com.google.gwt.core.ext.BadPropertyValueException;
+import com.google.gwt.core.ext.ConfigurationProperty;
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
@@ -13,21 +16,29 @@ import com.google.gwt.core.ext.typeinfo.JClassType;
 
 public class ReflectableTypesFinder implements TypesToReflectFinder {
 
+  private static final String REFLECTOR_TYPE_PROPERTY = "org.dt.reflector.rebind.finder.ReflectableTypesFinder.type";
+
   @Override
   public Set<TypeToReflect> findTypes(TreeLogger logger, GeneratorContext context) throws UnableToCompleteException {
     Set<TypeToReflect> typesToReflect = new HashSet<TypeToReflect>();
-    
-    JClassType markerType = getMarkerInterface(context);
-    
-    for (JClassType type : context.getTypeOracle().getTypes()) {
-      if (hasMarkerInterface(type, markerType)) {
-        typesToReflect.add(getTypeToReflect(logger, context, type));
-          for (JClassType nestedType : type.getNestedTypes()) {
-            if (hasMarkerInterface(nestedType, markerType)) {
-              typesToReflect.add(getTypeToReflect(logger, context, nestedType));
+
+    try {
+      List<JClassType> markerTypes = getMarkerInterfaces(context);
+      for (JClassType type : context.getTypeOracle().getTypes()) {
+        for(JClassType markerType: markerTypes) {
+          if (hasMarkerInterface(type, markerType)) {
+            typesToReflect.add(getTypeToReflect(logger, context, type));
+            for (JClassType nestedType : type.getNestedTypes()) {
+              if (hasMarkerInterface(nestedType, markerType)) {
+                typesToReflect.add(getTypeToReflect(logger, context, nestedType));
+              }
             }
           }
+        }
       }
+    } catch (BadPropertyValueException e) {
+      logger.log(TreeLogger.Type.ERROR, "Error reading configuration property: " + REFLECTOR_TYPE_PROPERTY, e);
+      throw new UnableToCompleteException();
     }
     
     return typesToReflect;
@@ -39,8 +50,13 @@ public class ReflectableTypesFinder implements TypesToReflectFinder {
     return new TypeToReflect(qualifiedSourceName, reflectorQualifiedSourceName);
   }
 
-  private JClassType getMarkerInterface(GeneratorContext context) {
-    return context.getTypeOracle().findType(Reflectable.class.getName());
+  private List<JClassType> getMarkerInterfaces(GeneratorContext context) throws BadPropertyValueException {
+    List<JClassType> classTypes = new LinkedList<JClassType>();
+    ConfigurationProperty configurationProperty = context.getPropertyOracle().getConfigurationProperty(REFLECTOR_TYPE_PROPERTY);
+    for (String s : configurationProperty.getValues()) {
+      classTypes.add(context.getTypeOracle().findType(s));
+    }
+    return classTypes;
   }
   
   /**

--- a/src/org/dt/reflector/rebind/finder/TypeToReflect.java
+++ b/src/org/dt/reflector/rebind/finder/TypeToReflect.java
@@ -45,7 +45,7 @@ public class TypeToReflect {
   }
   
   public String getDeferredCreateExpression() {
-    return "GWT.create("+qualifiedSourceName+".class)";
+    return "GWT.create("+reflectorQualifiedSourceName+".class)";
   }
   
   public String getImmediateCreateExpression() {


### PR DESCRIPTION
Why generate the reflactor when using GWT.create ? There is already the Oracle to do that
